### PR TITLE
Show Proton username without unnecessary suffix

### DIFF
--- a/src/dashboard/app.ts
+++ b/src/dashboard/app.ts
@@ -317,7 +317,11 @@ function renderAuthStatus(auth: AuthStatusUpdate): string {
 
   // Set authenticated label only when status is authenticated (to safely access username)
   if (auth.status === 'authenticated') {
-    const label = auth.username ? `${auth.username}` : 'Logged in';
+    const label = auth.username
+      ? auth.username.includes('@')
+        ? auth.username
+        : `${auth.username}@proton.me`
+      : 'Logged in';
     statusConfig.authenticated.label = label;
     if (loggedAuthUser !== label) {
       loggedAuthUser = label;


### PR DESCRIPTION
When user is logged in, the suffix @proton.me seems unneeded as it gets added to the primary proton e-mail address, resulting in `user@proton.me@proton.me`. This PR fixes that.