### PR TITLE
feat: add configurable watcher polling settings

### DIFF
--- a/src/sync/watcher.ts
+++ b/src/sync/watcher.ts
@@ -438,10 +438,13 @@ export async function setupWatchSubscriptions(
     }
 
     try {
+      const watcherConfig = config.watcher;
       const watcher = chokidar.watch(watchDir, {
         persistent: true,
         ignoreInitial: true, // Don't emit events for existing files
         alwaysStat: true, // Get stats with events (avoid extra statSync calls)
+        usePolling: watcherConfig.use_polling,
+        interval: watcherConfig.polling_interval,
         awaitWriteFinish: {
           stabilityThreshold: WATCHER_DEBOUNCE_MS,
           pollInterval: 100,


### PR DESCRIPTION
I'm running proton-drive-sync on linux with an external drive mounted via SSHFS, and I was getting "EMFILE: too many open files" errors when syncing large directories.
Turns out chokidar's use of Node.js fs.watch doesn't always work well on network filesystems.
Chokidar provides an alternative mode to use fs.watchFile when we set usePolling option on the watcher.
  
This PR adds two new config options under `watcher`:
 - `use_polling`: switches to polling mode (default: false)
 - `polling_interval`: how often to poll in ms (default: 5000)
  
I also added a "Watcher settings" option in the interactive config menu to easily configure this without editing the JSON manually.