### PR TITLE
fix: flatpak build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y dpkg-dev rpm flatpak flatpak-builder
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+          sudo flatpak install -y flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
 
       - name: Build .deb package
         run: ./packaging/scripts/build-deb.sh

--- a/packaging/flatpak/io.github.damianbbitflipper.ProtonDriveSync.yml.template
+++ b/packaging/flatpak/io.github.damianbbitflipper.ProtonDriveSync.yml.template
@@ -1,6 +1,6 @@
 app-id: io.github.damianbbitflipper.ProtonDriveSync
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: proton-drive-sync
 
@@ -16,6 +16,9 @@ finish-args:
 modules:
   - name: proton-drive-sync
     buildsystem: simple
+    build-options:
+      strip: false
+      no-debuginfo: true
     build-commands:
       - install -Dm755 proton-drive-sync /app/bin/proton-drive-sync
       - install -Dm644 io.github.damianbbitflipper.ProtonDriveSync.desktop /app/share/applications/io.github.damianbbitflipper.ProtonDriveSync.desktop


### PR DESCRIPTION
This fixes the flatpak build #61
The issue seems to occur when the binary is being stripped by the flatpak build.
This will be disabled by: 

```yaml
build-options:
      strip: false
      no-debuginfo: true
```

After fixing that, starting the binary resulted in the error:

```shell
error: libsecret-1.so.0: cannot open shared object file: No such file or directory
 code: "ERR_DLOPEN_FAILED"

      at <anonymous> (/$bunfs/root/proton-drive-sync:127:2375)
      at <anonymous> (/$bunfs/root/proton-drive-sync:2:618)
      at <anonymous> (/$bunfs/root/proton-drive-sync:127:2444)
      at <anonymous> (/$bunfs/root/proton-drive-sync:2:618)
      at /$bunfs/root/proton-drive-sync:256:24686
```

This is because runtime version `24.08` doesn't include libsecret.
Switching to runtime version `25.08` fixes that.

After that the `setup` command works:

```shell
$ flatpak run io.github.damianbbitflipper.ProtonDriveSync setup

  ____            _                ____       _              ____                   
 |  _ \ _ __ ___ | |_ ___  _ __   |  _ \ _ __(_)_   _____   / ___| _   _ _ __   ___ 
 | |_) | '__/ _ \| __/ _ \| '_ \  | | | | '__| \ \ / / _ \  \___ \| | | | '_ \ / __|
 |  __/| | | (_) | || (_) | | | | | |_| | |  | |\ V /  __/   ___) | |_| | | | | (__ 
 |_|   |_|  \___/ \__\___/|_| |_| |____/|_|  |_| \_/ \___|  |____/ \__, |_| |_|\___|
                                                                   |___/            


━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Remote Dashboard Access
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


  The dashboard is available at localhost:4242 by default.

  For headless/server installs, you can enable remote access by binding
  the web interface to all network interfaces (0.0.0.0:4242).

  WARNING: This exposes the dashboard to your network.
  The dashboard allows service control and configuration changes.
  Only enable this on trusted networks or behind a firewall.
```

Enabling as a system service on startup doesn't work:

```shell
error: Executable not found in $PATH: "systemctl"
```

But I guess that wouldn't work in a flatpak anyway.