### PR TITLE
Use drive api domain and update app-version

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -195,16 +195,12 @@ const INVALID_REFRESH_TOKEN_CODE = 10013;
 // Constants
 // ============================================================================
 
-const API_BASE_URL = 'https://api.protonmail.ch';
+const API_BASE_URL = 'https://drive-api.proton.me';
 const SRP_LEN = 256; // 2048 / 8, in bytes
 const AUTH_VERSION = 4;
 const BCRYPT_PREFIX = '$2y$10$';
-// Linux has no official APP_VERSION, so we masquerade as `macos`
-const PLATFORM_MAP: Record<string, string> = { darwin: 'macos', win32: 'windows' };
-const PLATFORM = PLATFORM_MAP[process.platform] ?? 'macos';
-const APP_VERSION =
-  PLATFORM === 'windows' ? `${PLATFORM}-drive@1.12.4` : `${PLATFORM}-drive@2.10.1`;
-const CHILD_CLIENT_ID = PLATFORM === 'macos' ? 'macOSDrive' : 'windowsDrive';
+const APP_VERSION = 'external-drive-proton_drive_sync@1.0.0';
+const CHILD_CLIENT_ID = 'ExternalDrive';
 
 // SRP Modulus verification key
 const SRP_MODULUS_KEY = `-----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Hi @DamianB-BitFlipper 

I'm an engineer in the Proton Drive team. We noticed you created this third party Proton Drive client using the SDK which is really cool. We would like to ask you to make a minor change in the way you interact with the API.

1. Change the domain to drive-api.proton.me
    - There are changes planned to the infrastructure so that Drive API endpoints are only available on the drive-api host, this'll ensure your client will keep working for you and users of this client in the future.
2. Change the app-version header
    -  We have added support for third-party app-version headers: `external-drive-<project>@<semver-version>`
    - The project name must conform to `-[a-z_]+`
    - The version can be any semver-compliant version number, you can inject your own version numbering if you want
    - This ensures that this client remains functional even if we perform a force-upgrade of one of our official clients, which would prevent a specific app-version from using the API
    - This would also help us with our metrics, as they currently report your client as the official MacOS/Windows clients, which causes problems for our team when debugging because errors from the official client get mixed in with errors from this project

We would be very grateful if you could adopt these changes, even though we cannot offer more support for third parties at this moment. 