### PR TITLE
sync: recover stale and blocked jobs more reliably

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -181,12 +181,16 @@ export function acquireRunLock(): boolean {
 
     if (pidStr) {
       const pid = parseInt(pidStr, 10);
-      if (!isNaN(pid) && isProcessRunning(pid)) {
+      if (!isNaN(pid) && pid === process.pid) {
+        // Stale self-lock can happen after container/service restarts where PID is reused.
+        clearFlag(RUNNING_PID_FLAG, pidStr, tx);
+      } else if (!isNaN(pid) && isProcessRunning(pid)) {
         // Process is still running, can't acquire lock
         return false;
+      } else {
+        // Process is dead, clear stale lock
+        clearFlag(RUNNING_PID_FLAG, pidStr, tx);
       }
-      // Process is dead, clear stale lock
-      clearFlag(RUNNING_PID_FLAG, pidStr, tx);
     }
 
     // Clear all stale signals

--- a/src/sync/constants.ts
+++ b/src/sync/constants.ts
@@ -14,8 +14,11 @@ export const JOB_POLL_INTERVAL_MS = 2_000;
 /** Timeout for graceful shutdown (2 seconds) */
 export const SHUTDOWN_TIMEOUT_MS = 2_000;
 
-/** Time after which a PROCESSING job is considered stale (10 minutes) */
-export const STALE_PROCESSING_MS = 10 * 60 * 1000;
+/** Time after which a PROCESSING job is considered stale (4 minutes) */
+export const STALE_PROCESSING_MS = 4 * 60 * 1000;
+
+/** Hard timeout for a single sync job operation before retrying (3 minutes) */
+export const JOB_EXECUTION_TIMEOUT_MS = 3 * 60 * 1000;
 
 /** Debounce time for file watcher events (200ms) - used for awaitWriteFinish stabilityThreshold */
 export const WATCHER_DEBOUNCE_MS = 200;
@@ -56,6 +59,15 @@ export const NETWORK_RETRY_CAP_INDEX = 4;
 
 /** Fixed retry delay for REUPLOAD_NEEDED errors (256 seconds) */
 export const REUPLOAD_NEEDED_RETRY_SEC = 256;
+
+/**
+ * Delay (seconds) before retrying jobs recovered from BLOCKED due to
+ * "Invalid access token" errors.
+ *
+ * Keeps retries bounded when auth is genuinely invalid while still allowing
+ * automatic recovery once token refresh starts working again.
+ */
+export const AUTH_BLOCKED_RECOVERY_RETRY_SEC = 300;
 
 /** Number of retries before attempting delete+recreate for REUPLOAD_NEEDED errors */
 export const REUPLOAD_DELETE_RECREATE_THRESHOLD = 2;

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -27,7 +27,7 @@ import {
   compareWithStoredChangeTokens,
   type FileChange,
 } from './watcher.js';
-import { enqueueJob, cleanupOrphanedJobs, getPendingJobCount } from './queue.js';
+import { enqueueJob, cleanupOrphanedJobs, getPendingJobCount, recoverBlockedJobs } from './queue.js';
 import {
   processAvailableJobs,
   waitForActiveTasks,
@@ -533,6 +533,7 @@ function startJobProcessorLoop(client: ProtonDriveClient, dryRun: boolean): Proc
   let running = true;
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   let loopCount = 0;
+  const blockedRecoveryIntervalLoops = Math.ceil(60_000 / JOB_POLL_INTERVAL_MS); // ~1 minute
   const processLoop = (): void => {
     loopCount++;
 
@@ -548,6 +549,10 @@ function startJobProcessorLoop(client: ProtonDriveClient, dryRun: boolean): Proc
     sendStatusToDashboard({ paused });
 
     if (!paused) {
+      // Periodically recover blocked jobs caused by transient remote/local races.
+      if (loopCount % blockedRecoveryIntervalLoops === 0) {
+        recoverBlockedJobs(dryRun);
+      }
       processAvailableJobs(client, dryRun);
     }
 

--- a/src/sync/processor.ts
+++ b/src/sync/processor.ts
@@ -35,6 +35,7 @@ import {
   deleteChangeTokensUnderPath,
 } from './fileState.js';
 import { scanDirectory } from './watcher.js';
+import { JOB_EXECUTION_TIMEOUT_MS } from './constants.js';
 
 // ============================================================================
 // Task Pool State (persistent across iterations)
@@ -42,6 +43,8 @@ import { scanDirectory } from './watcher.js';
 
 /** Active tasks: jobId -> promise */
 const activeTasks = new Map<number, Promise<void>>();
+/** Active task start times: jobId -> epoch ms */
+const activeTaskStartedAt = new Map<number, number>();
 
 // ============================================================================
 // Dynamic Concurrency
@@ -75,6 +78,30 @@ export function getActiveTaskCount(): number {
 }
 
 /**
+ * Recover in-memory worker slots from tasks that exceeded timeout budget.
+ * This is a safety net in case an underlying async operation never settles.
+ */
+function cleanupStaleActiveTasks(): void {
+  if (activeTasks.size === 0) return;
+
+  const now = Date.now();
+  const staleAfterMs = JOB_EXECUTION_TIMEOUT_MS + 30_000; // timeout + grace
+  let recovered = 0;
+
+  for (const [jobId, startedAt] of activeTaskStartedAt.entries()) {
+    if (now - startedAt <= staleAfterMs) continue;
+    activeTasks.delete(jobId);
+    activeTaskStartedAt.delete(jobId);
+    recovered++;
+    logger.warn(`Recovered stale in-memory task slot for job ${jobId}`);
+  }
+
+  if (recovered > 0) {
+    logger.warn(`Recovered ${recovered} stale in-memory task slot(s)`);
+  }
+}
+
+/**
  * Process all pending jobs until queue is empty (blocking).
  * Used for one-shot sync mode.
  */
@@ -92,8 +119,10 @@ export async function drainQueue(client: ProtonDriveClient, dryRun: boolean): Pr
       const jobId = job.id;
       const taskPromise = processJob(client, job, dryRun).finally(() => {
         activeTasks.delete(jobId);
+        activeTaskStartedAt.delete(jobId);
       });
       activeTasks.set(jobId, taskPromise);
+      activeTaskStartedAt.set(jobId, Date.now());
     }
 
     // Wait for at least one task to complete
@@ -110,6 +139,24 @@ export async function drainQueue(client: ProtonDriveClient, dryRun: boolean): Pr
 /** Extract error message from unknown error */
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** Wrap async operations to prevent hung workers from freezing the processor pool. */
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation: string): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error(`${operation} timed out after ${Math.floor(timeoutMs / 1000)}s`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
 }
 
 /** Helper to delete a node, throws on failure */
@@ -168,6 +215,8 @@ function buildChildRemotePath(
  * Call this periodically to keep the task pool saturated.
  */
 export function processAvailableJobs(client: ProtonDriveClient, dryRun: boolean): void {
+  cleanupStaleActiveTasks();
+
   // Calculate available capacity
   const availableSlots = syncConcurrency - activeTasks.size;
   if (availableSlots <= 0) return;
@@ -182,9 +231,11 @@ export function processAvailableJobs(client: ProtonDriveClient, dryRun: boolean)
     // Start the job and track it
     const taskPromise = processJob(client, job, dryRun).finally(() => {
       activeTasks.delete(jobId);
+      activeTaskStartedAt.delete(jobId);
     });
 
     activeTasks.set(jobId, taskPromise);
+    activeTaskStartedAt.set(jobId, Date.now());
   }
 }
 
@@ -199,6 +250,8 @@ async function processJob(client: ProtonDriveClient, job: Job, dryRun: boolean):
   }
 
   try {
+    const opLabel = `Job ${id} (${eventType}) ${remotePath}`;
+
     switch (eventType) {
       case SyncEventType.DELETE: {
         const config = getConfig();
@@ -210,7 +263,11 @@ async function processJob(client: ProtonDriveClient, job: Job, dryRun: boolean):
         const mapping = getNodeMapping(localPath, remotePath);
         const isDirectory = mapping?.isDirectory ?? false;
 
-        const { existed, trashed } = await deleteNodeOrThrow(client, remotePath, dryRun, trashOnly);
+        const { existed, trashed } = await withTimeout(
+          deleteNodeOrThrow(client, remotePath, dryRun, trashOnly),
+          JOB_EXECUTION_TIMEOUT_MS,
+          opLabel
+        );
         if (!existed) {
           logger.info(`Already gone: ${remotePath}`);
         } else {
@@ -234,11 +291,10 @@ async function processJob(client: ProtonDriveClient, job: Job, dryRun: boolean):
       case SyncEventType.UPDATE: {
         const typeLabel = eventType === SyncEventType.CREATE_FILE ? 'Creating' : 'Updating';
         logger.info(`${typeLabel}: ${remotePath}`);
-        const { nodeUid, parentNodeUid, isDirectory, contentSha1 } = await createNodeOrThrow(
-          client,
-          localPath,
-          remotePath,
-          dryRun
+        const { nodeUid, parentNodeUid, isDirectory, contentSha1 } = await withTimeout(
+          createNodeOrThrow(client, localPath, remotePath, dryRun),
+          JOB_EXECUTION_TIMEOUT_MS,
+          opLabel
         );
         logger.info(`Success: ${remotePath} -> ${nodeUid}`);
         // Store node mapping and file state for future operations
@@ -256,11 +312,10 @@ async function processJob(client: ProtonDriveClient, job: Job, dryRun: boolean):
         logger.info(`Creating directory: ${remotePath}`);
 
         // Step 1: Create the directory on remote
-        const { nodeUid, parentNodeUid } = await createNodeOrThrow(
-          client,
-          localPath,
-          remotePath,
-          dryRun
+        const { nodeUid, parentNodeUid } = await withTimeout(
+          createNodeOrThrow(client, localPath, remotePath, dryRun),
+          JOB_EXECUTION_TIMEOUT_MS,
+          opLabel
         );
         logger.info(`Directory created: ${remotePath} -> ${nodeUid}`);
 
@@ -275,7 +330,11 @@ async function processJob(client: ProtonDriveClient, job: Job, dryRun: boolean):
 
         // Step 3: Scan children and queue jobs for unsynced items
         const excludePatterns = getConfig().exclude_patterns;
-        const fsState = await scanDirectory(localPath, excludePatterns);
+        const fsState = await withTimeout(
+          scanDirectory(localPath, excludePatterns),
+          JOB_EXECUTION_TIMEOUT_MS,
+          `${opLabel} (scan children)`
+        );
 
         db.transaction((tx) => {
           for (const [childPath, stats] of fsState) {
@@ -337,6 +396,25 @@ async function processJob(client: ProtonDriveClient, job: Job, dryRun: boolean):
     }
   } catch (error) {
     const errorMessage = getErrorMessage(error);
+    const lowerError = errorMessage.toLowerCase();
+
+    // Idempotency guard:
+    // If a CREATE_FILE hits "already exists", the target object is already present remotely.
+    // Treat as success to avoid endless retry/block/re-enqueue loops on immutable Kopia chunks.
+    if (
+      eventType === SyncEventType.CREATE_FILE &&
+      lowerError.includes('a file or folder with that name already exists')
+    ) {
+      logger.warn(`Job ${id} (${localPath}) conflict on create, treating as synced: ${errorMessage}`);
+      db.transaction((tx) => {
+        if (job.changeToken) {
+          storeFileState(localPath, job.changeToken, null, dryRun, tx);
+        }
+        markJobSynced(id, localPath, dryRun, tx);
+      });
+      return;
+    }
+
     const { category: errorCategory, maxRetries } = categorizeError(errorMessage);
 
     if (nRetries >= maxRetries && maxRetries !== Infinity) {

--- a/src/sync/queue.ts
+++ b/src/sync/queue.ts
@@ -5,6 +5,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { existsSync } from 'fs';
 import { eq, and, lte, lt, inArray, isNull, sql, desc } from 'drizzle-orm';
 import { db, schema, run, type Tx } from '../db/index.js';
 import { SyncJobStatus, SyncEventType } from '../db/schema.js';
@@ -12,6 +13,7 @@ import { logger, isDebugEnabled } from '../logger.js';
 import { isPathWatched } from '../config.js';
 import {
   RETRY_DELAYS_SEC,
+  AUTH_BLOCKED_RECOVERY_RETRY_SEC,
   JITTER_FACTOR,
   STALE_PROCESSING_MS,
   NETWORK_RETRY_CAP_INDEX,
@@ -741,4 +743,126 @@ export function retryAllNow(): number {
   }
 
   return result.changes;
+}
+
+/**
+ * Recover jobs that were marked BLOCKED due to transient state races.
+ *
+ * - If job failed with "Invalid access token", move back to PENDING with cooldown.
+ * - If local file disappeared, mark as SYNCED (effectively skipped).
+ * - If local file exists and error was remote "file/folder not found",
+ *   move back to PENDING for another attempt.
+ */
+export function recoverBlockedJobs(
+  dryRun: boolean
+): { requeued: number; requeuedAuth: number; skippedMissingLocal: number } {
+  if (dryRun) {
+    return { requeued: 0, requeuedAuth: 0, skippedMissingLocal: 0 };
+  }
+
+  const blockedJobs = db
+    .select({
+      id: schema.syncJobs.id,
+      localPath: schema.syncJobs.localPath,
+      eventType: schema.syncJobs.eventType,
+      lastError: schema.syncJobs.lastError,
+    })
+    .from(schema.syncJobs)
+    .where(eq(schema.syncJobs.status, SyncJobStatus.BLOCKED))
+    .all();
+
+  if (blockedJobs.length === 0) {
+    return { requeued: 0, requeuedAuth: 0, skippedMissingLocal: 0 };
+  }
+
+  let requeued = 0;
+  let requeuedAuth = 0;
+  let skippedMissingLocal = 0;
+  const now = new Date();
+  const authRetryAt = new Date(Date.now() + AUTH_BLOCKED_RECOVERY_RETRY_SEC * 1000);
+
+  db.transaction((tx) => {
+    for (const job of blockedJobs) {
+      const lowerError = (job.lastError ?? '').toLowerCase();
+      const localExists = existsSync(job.localPath);
+
+      // Transient auth failure: retry later instead of requiring manual DB edits.
+      if (lowerError.includes('invalid access token')) {
+        run(
+          tx
+            .update(schema.syncJobs)
+            .set({
+              status: SyncJobStatus.PENDING,
+              retryAt: authRetryAt,
+              nRetries: 0,
+              lastError: null,
+            })
+            .where(eq(schema.syncJobs.id, job.id))
+        );
+        requeuedAuth++;
+        continue;
+      }
+
+      // Stale job: local path disappeared before retry attempts finished.
+      if (lowerError.includes('local path not found') && !localExists) {
+        run(
+          tx
+            .update(schema.syncJobs)
+            .set({
+              status: SyncJobStatus.SYNCED,
+              retryAt: now,
+              nRetries: 0,
+              lastError: 'Skipped: local path no longer exists',
+            })
+            .where(eq(schema.syncJobs.id, job.id))
+        );
+        skippedMissingLocal++;
+        continue;
+      }
+
+      // Recoverable race: remote "not found" but local still exists.
+      if (lowerError.includes('file or folder not found') && localExists) {
+        run(
+          tx
+            .update(schema.syncJobs)
+            .set({
+              status: SyncJobStatus.PENDING,
+              retryAt: now,
+              nRetries: 0,
+              lastError: null,
+            })
+            .where(eq(schema.syncJobs.id, job.id))
+        );
+        requeued++;
+        continue;
+      }
+
+      // DELETE jobs don't require local file presence for remote cleanup.
+      if (
+        lowerError.includes('file or folder not found') &&
+        job.eventType === SyncEventType.DELETE
+      ) {
+        run(
+          tx
+            .update(schema.syncJobs)
+            .set({
+              status: SyncJobStatus.PENDING,
+              retryAt: now,
+              nRetries: 0,
+              lastError: null,
+            })
+            .where(eq(schema.syncJobs.id, job.id))
+        );
+        requeued++;
+      }
+    }
+  });
+
+  if (requeued > 0 || requeuedAuth > 0 || skippedMissingLocal > 0) {
+    logger.info(
+      `Recovered blocked jobs: requeued=${requeued}, requeued_auth=${requeuedAuth}, skipped_missing_local=${skippedMissingLocal}`
+    );
+  }
+
+  return { requeued, requeuedAuth, skippedMissingLocal };
 }


### PR DESCRIPTION
## Problem

Some sync jobs can get stuck in `BLOCKED` or leave the worker pool effectively wedged after long-running or hung operations. In practice this can require manual intervention even when the underlying condition is transient. Something to note is that I've only been running this app in Docker (And encountered these issues there), so non-docker is untested.

## Changes

- recover stale `RUNNING_PID` self-locks caused by PID reuse
- add execution timeouts around long-running job operations
- reclaim stale in-memory worker slots when a task never settles
- periodically recover blocked jobs in the processor loop
- requeue blocked jobs caused by transient auth failures with cooldown
- requeue recoverable remote `not found` races when the local path still exists
- mark missing-local blocked jobs as skipped/synced
- treat create-file name conflicts as idempotent success to avoid endless retries

## Validation

Tested against real sync workloads where jobs became blocked or workers stalled, including:
- transient `Invalid access token` failures
- remote `file or folder not found` races
- immutable-file create conflicts
- stale worker slots after long-running operations