### PR TITLE
Fix: docker auth errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ dist/
 .DS_Store
 *.log
 *.bun-build
-
+docker/.env
 my_*

--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -40,18 +40,12 @@ Run Proton Drive Sync in Docker with support for Linux x86_64 and ARM64.
    - ${SYNC_DIR_2}:/data/photos
    ```
 
-3. **Start the container**
-
-   ```bash
-   docker compose up -d
-   ```
-
-4. **Authenticate with Proton**
+3. **Authenticate with Proton**
 
    **Option A: Interactive** (supports 2FA)
 
    ```bash
-   docker exec -it proton-drive-sync proton-drive-sync auth
+   docker compose run -it --rm proton-drive-sync proton-drive-sync auth
    ```
 
    Follow the prompts to enter your Proton credentials and 2FA code if enabled.
@@ -60,11 +54,14 @@ Run Proton Drive Sync in Docker with support for Linux x86_64 and ARM64.
 
    Uncomment and set `PROTON_USERNAME` and `PROTON_PASSWORD` in your `.env` file, then restart:
 
+   The app will authenticate automatically on startup. Note: this does **not** work with accounts that have 2FA/TOTP enabled.
+
+4. **Start the container**
+
    ```bash
    docker compose up -d
    ```
 
-   The app will authenticate automatically on startup. Note: this does **not** work with accounts that have 2FA/TOTP enabled.
 
 5. **Configure sync directories**
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ See **[DOCKER_SETUP.md](DOCKER_SETUP.md)** for running with Docker Compose on Li
 cd docker/
 cp .env.example .env
 # Edit .env with KEYRING_PASSWORD and sync directory paths
+docker compose run -it --rm proton-drive-sync proton-drive-sync auth
 docker compose up -d
-docker exec -it proton-drive-sync proton-drive-sync auth
 ```
 
 ### Coming Soon

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,13 @@ set -e
 # Ensure persistent and data directories exist
 mkdir -p /config/proton-drive-sync /state/proton-drive-sync /data
 
+# If arguments are passed (e.g. "docker compose run ... proton-drive-sync auth"),
+# run them directly instead of starting the sync server
+if [ $# -gt 0 ]; then
+  exec "$@"
+fi
+
 # Start sync in foreground (no daemon mode)
 # Using exec so signals (SIGTERM, SIGINT) go directly to the app
 echo "Starting Proton Drive Sync..."
-exec proton-drive-sync start --no-daemon "$@"
+exec proton-drive-sync start --no-daemon

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -8,7 +8,6 @@
  * - Linux without KEYRING_PASSWORD: libsecret via keytar (for desktop environments)
  */
 
-import keytar from 'keytar';
 import { logger } from './logger.js';
 import type { PasswordMode } from './auth.js';
 import {
@@ -28,6 +27,13 @@ const DEFAULT_KEYRING_PASSWORD = 'proton-drive-sync';
  */
 function useFileStorage(): boolean {
   return process.platform === 'linux';
+}
+
+/**
+ * Dynamically import keytar to avoid loading libsecret on Linux when it's not needed.
+ */
+async function getKeytar() {
+  return (await import('keytar')).default;
 }
 
 /**
@@ -62,6 +68,7 @@ export async function getStoredCredentials(): Promise<StoredCredentials | null> 
     }
 
     // macOS/Windows/Linux desktop: use keytar
+    const keytar = await getKeytar();
     const data = await keytar.getPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
     if (!data) return null;
     return JSON.parse(data) as StoredCredentials;
@@ -79,6 +86,7 @@ export async function storeCredentials(credentials: StoredCredentials): Promise<
   }
 
   // macOS/Windows/Linux desktop: use keytar
+  const keytar = await getKeytar();
   await keytar.setPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, JSON.stringify(credentials));
 }
 
@@ -91,6 +99,7 @@ export async function deleteStoredCredentials(): Promise<void> {
     }
 
     // macOS/Windows/Linux desktop: use keytar
+    const keytar = await getKeytar();
     await keytar.deletePassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
   } catch {
     // Ignore - may not exist


### PR DESCRIPTION
- Fix libsecret errors by importing keytar only when needed
- Fix entrypoint.sh to correctly pass docker exec or run args
- Change docker compose commands from `exec` to `run` to avoid auth errors while server is in a boot loop

I'm wondering if anyone else is using proton-drive-sync in docker without such fixes?