### PR TITLE
Fix https://github.com/DamianB-BitFlipper/proton-drive-sync/issues/24

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -899,16 +899,6 @@ export class ProtonAuth {
             }
           }
 
-          // Fallback to the user's key password - only valid for single-password mode
-          if (!addressKeyPassword) {
-            if (passwordMode === 2) {
-              throw new Error(
-                `Failed to derive passphrase for address key ${key.ID} in two-password mode. Re-authentication required.`
-              );
-            }
-            addressKeyPassword = keyPassword;
-          }
-
           // Verify passphrase by attempting to decrypt the address key (two-password mode only)
           if (addressKeyPassword && passwordMode === 2) {
             try {


### PR DESCRIPTION
This fallback always yielded an incorrect passphrase in my testing, remove it and error out if this case happens.

Please do test this case in other setups and see if it was needed.

Hit me up if you know more about this issue or if this is not the correct fix.